### PR TITLE
fix: Исправил поведение фильтра на странице со списком постов

### DIFF
--- a/src/app/features/post/post-list/components/filter/container/post-list-filter-container.component.ts
+++ b/src/app/features/post/post-list/components/filter/container/post-list-filter-container.component.ts
@@ -9,6 +9,7 @@ import { select, Store } from '@ngrx/store';
 import { State } from '../../../../../../core/ngrx-store/reducers';
 import { PageableFilterField } from '../../../../../../core/types/pagination/pageable';
 import * as postActions from '../../../../../../core/ngrx-store/actions/post.actions';
+import { postListInitialPageable } from '../../../ngrx-store/post-list.reducer';
 
 @Component({
   selector: 'app-post-list-filter-container',
@@ -26,6 +27,7 @@ export class PostListFilterContainerComponent {
     this.store.dispatch(
       new postActions.GetPosts({
         ...pageable,
+        page: postListInitialPageable.page,
         filter,
       }),
     );

--- a/src/app/features/post/post-list/components/page/post-list-page.component.ts
+++ b/src/app/features/post/post-list/components/page/post-list-page.component.ts
@@ -14,6 +14,7 @@ import * as userActions from '../../../../../core/ngrx-store/actions/user.action
 import { Pageable, PageableSortField } from '../../../../../core/types/pagination/pageable';
 import { selectIsActionInProcess } from '../../../../../core/ngrx-store/selectors/current-actions.selectors';
 import { GET_POSTS } from '../../../../../core/ngrx-store/actions/post.actions';
+import { postListInitialPageable } from '../../ngrx-store/post-list.reducer';
 
 @Component({
   selector: 'app-post-list-page',
@@ -43,10 +44,8 @@ export class PostListPageComponent implements OnInit {
 
   constructor(private store: Store<State>) {}
 
-  async ngOnInit(): Promise<void> {
-    const pageable = await firstValueFrom(this.pageable$);
-
-    this.store.dispatch(new postActions.GetPosts(pageable));
+  ngOnInit(): void {
+    this.store.dispatch(new postActions.GetPosts(postListInitialPageable));
     this.store.dispatch(new userActions.GetUsers());
   }
 

--- a/src/app/features/post/post-list/ngrx-store/post-list.reducer.spec.ts
+++ b/src/app/features/post/post-list/ngrx-store/post-list.reducer.spec.ts
@@ -1,13 +1,13 @@
-import { reducer, initialState } from './post-list.reducer';
+import { reducer, postListInitialState } from './post-list.reducer';
 
 describe('PostList Reducer', () => {
   describe('an unknown action', () => {
     it('should return the previous state', () => {
       const action = {} as any;
 
-      const result = reducer(initialState, action);
+      const result = reducer(postListInitialState, action);
 
-      expect(result).toBe(initialState);
+      expect(result).toBe(postListInitialState);
     });
   });
 });

--- a/src/app/features/post/post-list/ngrx-store/post-list.reducer.ts
+++ b/src/app/features/post/post-list/ngrx-store/post-list.reducer.ts
@@ -2,12 +2,13 @@ import { PayloadAction } from '../../../../core/ngrx-store/types/payload-action'
 import * as postActions from '../../../../core/ngrx-store/actions/post.actions';
 import NormalizedData from '../../../../core/normalizr/types/normalized-data';
 import { PageResult } from '../../../../core/types/pagination/page-result';
+import { Pageable } from '../../../../core/types/pagination/pageable';
 
 export const postListFeatureKey = 'postList';
 
 export type PostListState = PageResult<number>;
 
-export const initialState: PostListState = {
+export const postListInitialPageable: Pageable = {
   page: {
     number: 1,
     size: 5,
@@ -16,12 +17,15 @@ export const initialState: PostListState = {
     field: 'id',
     direction: 'asc',
   },
+};
+export const postListInitialState: PostListState = {
+  ...postListInitialPageable,
   totalCount: 0,
   items: [],
 };
 
 // eslint-disable-next-line @typescript-eslint/default-param-last
-export function reducer(state = initialState, action: PayloadAction<any>): PostListState {
+export function reducer(state = postListInitialState, action: PayloadAction<any>): PostListState {
   switch (action.type) {
     case postActions.GET_POSTS_SUCCESS:
       const data = action.payload as NormalizedData<PageResult<number>>;


### PR DESCRIPTION
Сделал следующее:
1. При открытии страницы фильтр сбрасывается для того, чтобы не применялись старые фильтры
2. При изменении фильтра устанавливается первая страницы